### PR TITLE
ci(approval): run approval tests before build in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,21 @@ on:
       - '.claude/**'
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: cd approval && bun install
+
+      - name: Run approval tests
+        run: cd approval && bun test
+
   build:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The build job now depends on a test job that runs bun test in approval/. If any test fails, the Docker build and push is skipped.