### PR TITLE
feat(network): allow storage.googleapis.com for claude install

### DIFF
--- a/network/domains.conf
+++ b/network/domains.conf
@@ -4,6 +4,7 @@ statsig.anthropic.com
 console.anthropic.com
 platform.claude.com
 raw.githubusercontent.com
+storage.googleapis.com
 
 # GitHub
 github.com


### PR DESCRIPTION
Claude Code distributes its release artifacts via Google Cloud Storage. Without this domain in the allowlist, `claude install` fails with ECONNREFUSED when fetching the latest version manifest.