### PR TITLE
fix(approval): anchor source rule to command position

### DIFF
--- a/approval/__tests__/tiers.test.ts
+++ b/approval/__tests__/tiers.test.ts
@@ -22,6 +22,7 @@ describe("Tier 1: hard-block", () => {
     "(source ~/.bashrc)", // source in subshell
     "$(source ~/.bashrc)", // source in command substitution
     "cd /tmp && source ~/.bashrc", // source in compound command
+    "echo ok\nsource ~/.bashrc", // source after newline-separated command
     "printenv",
     "approve bun add react",
     // Compound commands — unanchored word-boundary rules still catch these

--- a/approval/rules.conf
+++ b/approval/rules.conf
@@ -10,7 +10,7 @@ block:\beval\b
 # exec: anchored to command position (including subshells) to avoid blocking "npm exec"
 block-pattern:(^\s*|[;&|({$]\s*)exec\b
 # source: anchored to command position (including subshells) to avoid blocking "--source" flags
-block-pattern:(^\s*|[;&|({$]\s*)source\b
+block-pattern:(^\s*|[;&|({$\n]\s*)source\b
 block:\bprintenv\b
 block:\bxargs\b
 block:\bapprove\b


### PR DESCRIPTION
## Summary

- Fix false positive where `block:\bsource\b` matches `--source` in CLI flags (e.g., `gh repo sync --source perezd/claudetainer --branch main`)
- Change to command-position-anchored `block-pattern:(^\s*|[;&|({$]\s*)source\b`, following the existing `exec` rule pattern
- Add regression tests: compound-command source block, and two `--source` flag allow cases

## Layer-Impact Assessment

- **Affected layer:** Command Approval (Tier 1 block rules)
- **Why:** Narrowing `source` match from word-boundary to command-position anchor to eliminate false positives on `--source` flags
- **Panel review:** All 4 core panelists approved with no concerns

## Panel Review

| Panelist | Verdict |
|----------|---------|
| Linux Container Security Specialist | approve |
| Cloud Infrastructure Security Engineer | approve |
| Offensive Security / Red Team Analyst | approve |
| Compliance and Risk Management Advisor | approve |

Key findings: Pattern follows identical approach to existing `exec` rule. No new attack surface. Shell `source` at command position still blocked. Backtick subshell limitation is pre-existing and shared with `exec` rule.

## Test Plan

- [x] `source ~/.bashrc` — still blocked (start of string)
- [x] `cd /tmp && source ~/.bashrc` — still blocked (compound command)
- [x] `outsource project` — still not blocked (substring)
- [x] `gh repo sync --source perezd/claudetainer --branch main` — now correctly NOT blocked
- [x] `gh repo sync --source ... && git pull origin main` — now correctly NOT blocked
- [x] All 157 tests pass