### PR TITLE
fix(entrypoint): remove plugin cache pre-seeding that prevents registration

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -135,20 +135,6 @@ chmod 644 /home/claude/.npmrc
 cp /opt/claude/settings.json /home/claude/.claude/settings.json
 chown claude:claude /home/claude/.claude/settings.json
 
-# Seed superpowers plugin cache (cloned at build time, avoids runtime download)
-if [ -d /opt/claude-plugins/superpowers ]; then
-  mkdir -p /home/claude/.claude/plugins/cache/claude-plugins-official
-  cp -r /opt/claude-plugins/superpowers /home/claude/.claude/plugins/cache/claude-plugins-official/
-  chown -R claude:claude /home/claude/.claude/plugins
-fi
-
-# Seed TypeScript LSP plugin cache (cloned at build time, avoids runtime download)
-if [ -d /opt/claude-plugins/typescript-lsp ]; then
-  mkdir -p /home/claude/.claude/plugins/cache/claude-plugins-official
-  cp -r /opt/claude-plugins/typescript-lsp /home/claude/.claude/plugins/cache/claude-plugins-official/
-  chown -R claude:claude /home/claude/.claude/plugins
-fi
-
 # Write Claude Code state (onboarding skip + project trust written after clone below)
 echo '{"hasCompletedOnboarding": true}' > /home/claude/.claude.json
 chown claude:claude /home/claude/.claude.json


### PR DESCRIPTION
## Summary

- Removes the plugin cache pre-seeding steps from `scripts/entrypoint.sh` that copied raw git clones into the plugin cache before `claude plugin install` ran
- Fixes the root cause of plugins not loading on session startup (requiring manual `/reload-plugins`)

## Root cause

The entrypoint pre-seeded the plugin cache by copying raw git clones to `~/.claude/plugins/cache/claude-plugins-official/<plugin>/`. This put root-level repo files (package.json, README.md, .gitignore, etc.) directly in the cache directory. When `claude plugin install` subsequently ran, it created a proper versioned subdirectory (e.g., `5.0.6/`) but failed to register the plugin in `installed_plugins.json`.

Evidence: `installed_plugins.json` contained only `typescript-lsp` -- superpowers was completely absent despite its files existing on disk. Without a manifest entry, Claude Code did not recognize it as installed on startup.

## Fix

Remove the pre-seed steps entirely. `claude plugin install` handles the full lifecycle: marketplace lookup, download, versioned cache directory creation, and registration in `installed_plugins.json`.

Note: The Dockerfile still pre-clones plugins to `/opt/claude-plugins/` -- this is now dead code and can be cleaned up in a follow-up.

## Layer-impact assessment

- Security layers affected: Container Hardening (entrypoint modification)
- Why: Removing code from `scripts/entrypoint.sh` that runs as root during boot. The change is strictly a deletion -- no new code paths, no privilege changes, no credential handling changes.
- Panel review: Triggered (entrypoint is a security-layer file)

## Panel review

### Core panel

1. Linux container security specialist -- APPROVE. Pure deletion of `cp -r` and `chown` operations. No new attack surface. Plugin installation still runs as `claude` user via `sudo -u claude`. Filesystem hardening chain is preserved (tmpfs, setup, read-only remount).

2. Cloud infrastructure security engineer -- APPROVE. The removed code copied files and changed ownership -- standard operations with no security implications on removal. The `claude plugin install` commands that remain are unchanged and already ran after the seed steps.

3. Offensive security / red team analyst -- APPROVE. The pre-seed steps were not a security control -- they were a performance optimization. Removing them does not open any new vectors. The plugin install commands still run with the same restricted environment variables and user context.

4. Compliance and risk management advisor -- APPROVE. No credential handling changes. No new binaries or packages. Boot sequence dependency chain is preserved. Readiness checks for plugin directories still apply (they verify the dirs exist regardless of how they were created).

All experts: APPROVE -- no concerns.

## Test plan

- [ ] Deploy to a test machine and verify `installed_plugins.json` contains both `superpowers` and `typescript-lsp` after boot
- [ ] Verify plugins load without requiring `/reload-plugins` on first SSH session
- [ ] Verify readiness checks pass (`status` command shows all green)
