### PR TITLE
feat(fly): add launch scripts for ephemeral machine runs

### DIFF
--- a/fly/config.sh
+++ b/fly/config.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Shared configuration for fly machine run commands.
+
+APP="claudetainer"
+IMAGE="ghcr.io/perezd/claudetainer:latest"
+
+COMMON_FLAGS=(
+  --app "$APP"
+  --region sjc
+  --restart no
+  --autostart=false
+  --vm-memory 4096
+  --vm-size shared-cpu-2x
+)

--- a/fly/launch-debug.sh
+++ b/fly/launch-debug.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+exec fly machine run "$REPO_ROOT" --dockerfile Dockerfile "${COMMON_FLAGS[@]}" "$@"

--- a/fly/launch.sh
+++ b/fly/launch.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+
+exec fly machine run "$IMAGE" "${COMMON_FLAGS[@]}" "$@"


### PR DESCRIPTION
## Summary
- Adds `fly/` directory with shared config and launch scripts for `fly machine run`
- `fly/launch.sh` runs the published `ghcr.io/perezd/claudetainer:latest` image
- `fly/launch-debug.sh` builds from the local Dockerfile via `--dockerfile`
- Common flags (app, region, vm size, restart policy) live in `fly/config.sh` to avoid duplication
- Both scripts pass through `"$@"` for additional flags (e.g., `-e GH_PAT=xxx`)

## Test plan
- [ ] Run `./fly/launch.sh` and verify machine starts with expected config
- [ ] Run `./fly/launch-debug.sh` and verify it builds from local Dockerfile
- [ ] Verify extra flags pass through (e.g., `./fly/launch.sh --region ord`)