### PR TITLE
feat: add issue-driven workflow section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ All design specs and implementation plans produced by the brainstorming and writ
 
 The issue accumulates comments in this order:
 
-1. **Design comment** — Posted only after the full panel review process (see Modification Protocol) completes with all experts signing off. This is a stable, reviewed artifact and should not need frequent updates.
+1. **Design comment** — The full panel review process (see Modification Protocol) **must complete with all experts signing off before this comment is posted**. Run multiple rounds if needed until the panel approves without concerns. The design comment must represent a vetted consensus, not a draft. Once posted, it is a stable artifact and should not need frequent updates.
 2. **Implementation plan comment** — Uses Markdown checkboxes (`- [ ]` / `- [x]`). As tasks are completed during execution, Claude edits this comment via `gh api` to mark items done, providing real-time progress visibility on the issue.
 3. **Supplemental comments** (only if needed) — If significant design issues are discovered during execution, post a new comment explaining what deviated and why. The original design comment is preserved as a historical record; deviations are made explicit rather than silently rewritten.
 4. **After-Action Report (AAR)** — Posted after all associated PRs are merged to main. This is the final action taken on the issue. Required sections:


### PR DESCRIPTION
## Summary

Adds an "Issue-Driven Workflow" section to CLAUDE.md that redirects brainstorming and planning artifacts to GitHub issue comments when Claude is given an explicit issue reference.

- Design specs and implementation plans are posted as issue comments instead of local files
- Defines a four-part comment sequence: design, implementation plan (with checkboxes), supplemental (if needed), AAR
- PR bodies must include `Closes #N` for automatic issue closure
- Recommends `--body-file` over inline `--body` for `gh` commands to avoid approval classifier false positives

## Layer-Impact Assessment

- **Security layers affected:** None
- **Why:** Documentation-only change to CLAUDE.md — no code, no scripts, no security layer files modified
- **Panel review:** Completed — all four core experts approved with no concerns

## Test Plan

- [ ] Verify CLAUDE.md passes `bunx prettier --check`
- [ ] Verify the new section appears after "Required Skills"
- [ ] Confirm no existing sections were modified

Closes #24
