### PR TITLE
chore(ci): trigger builds on CLAUDE.md edits and add manual dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build and Push
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
## Summary

- Trigger CI builds when `CLAUDE.md` is edited (previously ignored by `*.md` glob)
- Add `workflow_dispatch` event to allow manual build triggers from the Actions UI

## Test plan

- [ ] Verify workflow runs on manual dispatch from GitHub Actions UI
- [ ] Verify workflow triggers when CLAUDE.md is modified in a push to main
