### PR TITLE
docs: add session initialization section for fork sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,14 @@ The panel is not a rubber stamp. Genuinely reason from each expert's perspective
 
 ## Git Workflow
 
+### Session Initialization
+
+Before beginning any task, complete these initialization steps in order:
+
+1. **Sync with upstream** — Run `gh repo view --json isFork,parent` to check if the repo is a fork. If it is a fork, sync main with upstream: `gh repo sync <fork-owner>/<fork-repo> --source <parent-owner>/<parent-repo> --branch main`, then `git pull origin main`. If the repo is not a fork, run `git pull origin main` to ensure the local checkout is current with its remote. If the sync or pull fails, warn the user and proceed — do not block the task.
+
+All work — whether writing code, answering questions, or reviewing files — must be based on the latest upstream state. This step runs from the main branch before any worktree is created.
+
 ### Worktree-First Development
 
 All changes happen in git worktrees, never directly on main. Each worktree gets a descriptive branch name reflecting the change.


### PR DESCRIPTION
## Summary

- Adds a "Session Initialization" subsection as the first entry under "## Git Workflow" in CLAUDE.md
- Ensures the repo is synced with upstream (for forks) or its remote (for non-forks) before beginning any task
- Applies to all work — code changes, explanations, reviews — so everything is based on the latest source of truth

## Layer-Impact Assessment

- **Affected layers:** None
- **Why:** CLAUDE.md instructions only. No security-layer files touched. Uses standard git operations with already-configured authentication.
- **Panel review triggered:** No — no security-layer files are modified.

## Test Plan

- [ ] Verify the new section appears first under "## Git Workflow", before "Worktree-First Development"
- [ ] Verify `bunx prettier --check CLAUDE.md` passes
- [ ] Confirm no spec or plan files are included in the diff
