### PR TITLE
docs: add bug triage routing to issue-driven workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ When Claude is explicitly given a GitHub issue URL or reference (e.g., `#24`, `o
 
 ### Bug Triage
 
-When an issue is a bug, regression, or report of unexpected behavior — whether indicated by GitHub labels (e.g., `bug`, `regression`) or by the issue description — invoke `/systematic-debugging` before proceeding with the standard brainstorming workflow. Identify the root cause first, then design the fix. When it is unclear whether an issue is a bug or a feature request, default to treating it as a bug — it is lower cost to debug unnecessarily than to skip root-cause analysis on a real defect.
+When an issue is a bug, regression, or report of unexpected behavior — whether indicated by GitHub labels (e.g., `bug`, `regression`) or by the issue description — invoke `/systematic-debugging` before proceeding with `/brainstorming` and `/writing-plans`. Identify the root cause first, then design the fix. When it is unclear whether an issue is a bug or a feature request, default to treating it as a bug — it is lower cost to debug unnecessarily than to skip root-cause analysis on a real defect.
 
 ### Artifact Routing
 


### PR DESCRIPTION
## Summary

- Adds a "Bug Triage" subsection to the Issue-Driven Workflow section of CLAUDE.md
- Routes bug/regression/unexpected-behavior issues through `/systematic-debugging` before the standard brainstorming workflow
- Provides a default for ambiguous issues: treat as a bug (lower cost to debug unnecessarily than to miss root-cause analysis)

## Layer-Impact Assessment

- **Affected layers:** None
- **Why:** CLAUDE.md instructions only. No security-layer files touched.
- **Panel review triggered:** No

## Test Plan

- [ ] Verify the new "Bug Triage" subsection appears between the Issue-Driven Workflow intro and "Artifact Routing"
- [ ] Verify language aligns with existing Required Skills table trigger for `/systematic-debugging`
- [ ] Verify `bunx prettier --check CLAUDE.md` passes
