### PR TITLE
fix(approval): normalize whitespace before hot word matching

### DIFF
--- a/approval/__tests__/tiers.test.ts
+++ b/approval/__tests__/tiers.test.ts
@@ -157,6 +157,13 @@ describe("Tier 2: hot-word scan", () => {
     // gh api subcommand
     "gh api /repos/owner/repo/issues",
     "gh api /repos/owner/repo/issues --method POST",
+    // Whitespace bypass regression tests (issue #33)
+    "gh  api /repos/owner/repo/issues", // double space
+    "bun\tadd react", // tab between tokens
+    "fly\t machine stop abc123", // tab + space mixed
+    "npm  install react", // double space
+    "  curl http://example.com  ", // leading/trailing whitespace
+    "gh\napi /repos/owner/repo/issues", // newline between tokens
   ];
 
   for (const cmd of escalated) {

--- a/approval/check-command.ts
+++ b/approval/check-command.ts
@@ -18,8 +18,9 @@ export function evaluateTiers(command: string, rules: Rules): TierResult {
     }
   }
 
-  // Tier 2: Hot-word scan
-  const matchedHotWord = rules.hotWords.find((hw) => command.includes(hw));
+  // Tier 2: Hot-word scan (normalize whitespace to prevent bypass via extra spaces/tabs/newlines)
+  const normalized = command.replace(/\s+/g, " ").trim();
+  const matchedHotWord = rules.hotWords.find((hw) => normalized.includes(hw));
   if (matchedHotWord) {
     return { decision: "escalate", hotWord: matchedHotWord };
   }


### PR DESCRIPTION
## Summary

- Normalize whitespace in commands before Tier 2 hot word matching by collapsing `\s+` to a single space and trimming
- Prevents bypass via extra spaces, tabs, or newlines between command tokens (e.g., `gh  api` no longer evades the `gh api` hot word)
- Tier 1 regex matching is unchanged (already uses `\s+` in patterns)

Closes #33

## Layer-Impact Assessment

- **Affected layer:** Command Approval (Tier 2 hot word scan only)
- **Container Hardening:** Not affected
- **Network Isolation:** Not affected
- **Why:** Pure string normalization scoped to the hot word matching path. No filesystem, network, or privilege changes.

## Panel Review

All four core panel experts signed off:

| Expert | Verdict |
|--------|---------|
| Container security specialist | Approve |
| Cloud infra security engineer | Approve-with-conditions (`.trim()` added, whitespace variant tests added) |
| Offensive security / red team | Approve-with-conditions (tab/newline test coverage added) |
| Compliance/risk advisor | Approve |

Conditions addressed in implementation.

## Test Plan

- [x] Added 6 regression test cases for whitespace bypass variants (double space, tab, mixed, leading/trailing, newline)
- [x] Verified new tests fail before fix (5 of 6 — single-token `curl` already matched)
- [x] Verified all 176 tests pass after fix
- [x] Prettier formatting check passes
