### PR TITLE
docs: default finishing-a-development-branch to push and create PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,10 @@ These superpowers skills are mandatory process gates — not optional.
 
 `/systematic-debugging` and `/receiving-code-review` are reactive — invoke when their triggers occur at any point.
 
+### Skill Overrides
+
+**`/finishing-a-development-branch`:** Always default to "Push and create a Pull Request" (Option 2) without presenting the interactive prompt. This aligns with the project's PR-based integration model — all changes go through pull requests. Only deviate from this default if the user has explicitly instructed otherwise in advance.
+
 ---
 
 ## Issue-Driven Workflow


### PR DESCRIPTION
## Summary

- Override the `finishing-a-development-branch` skill to always default to "Push and create a Pull Request" without presenting the interactive 4-option prompt
- Adds a "Skill Overrides" subsection to the Required Skills section of `CLAUDE.md`
- Aligns with the project's existing PR-based integration model

## Layer-Impact Assessment

- **Security layers affected:** None — this is a behavioral directive for Claude, not a change to container hardening, network isolation, or command approval
- **Panel review:** Not required

## Test Plan

- [x] Verify `bunx prettier --check CLAUDE.md` passes (confirmed unchanged by prettier)
- [x] Verify the new section renders correctly in Markdown
- [x] Confirm the directive is respected by Claude when invoking `/finishing-a-development-branch`

Closes #37
