### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/perezd/claudetainer/security/code-scanning/1](https://github.com/perezd/claudetainer/security/code-scanning/1)

To fix this, explicitly declare minimal `GITHUB_TOKEN` permissions for the `test` job so it no longer inherits potentially broad repository defaults. The job only checks out code and runs tests, so it only needs read access to the repository contents.

The best targeted fix without changing functionality is to add a `permissions` block under the `test` job, immediately below `runs-on: ubuntu-latest`, specifying `contents: read`. This mirrors GitHub’s recommended minimal starting point and is consistent with how `build` already declares its own permissions. No other steps or jobs need to be changed, and no imports or external libraries are involved because this is a workflow YAML file.

Concretely, in `.github/workflows/build.yml`, within the `jobs.test` definition, insert:

```yaml
permissions:
  contents: read
```

right after `runs-on: ubuntu-latest`. The rest of the workflow remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
