### PR TITLE
chore: always prefer subagent-driven development when executing plans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,8 @@ These superpowers skills are mandatory process gates — not optional.
 
 ### Skill Overrides
 
+**`/executing-plans`:** Always use `superpowers:subagent-driven-development` instead of the base executing-plans skill. Skip the selection prompt — subagent-driven development is the default execution strategy. Only deviate if the user has explicitly instructed otherwise in advance.
+
 **`/finishing-a-development-branch`:** Always default to "Push and create a Pull Request" (Option 2) without presenting the interactive prompt. This aligns with the project's PR-based integration model — all changes go through pull requests. Only deviate from this default if the user has explicitly instructed otherwise in advance.
 
 ---


### PR DESCRIPTION
## Summary

- Adds a skill override for `/executing-plans` to always use `superpowers:subagent-driven-development` by default, eliminating the manual selection prompt
- Follows the same pattern as the existing `/finishing-a-development-branch` override

## Layer-Impact Assessment

- **Affected layers:** None
- **Why:** Documentation-only change to CLAUDE.md workflow instructions — no security layer files are modified
- **Panel review:** Not triggered

## Test Plan

- [ ] Verify the override text is correctly placed in the Skill Overrides section
- [ ] Confirm formatting passes `bunx prettier --check CLAUDE.md`

Closes #40
