### PR TITLE
docs: add atomic PR description update guidance to PR Lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,8 @@ This must be done after each upstream merge to keep the fork and local checkout 
 
 After creating a PR, poll periodically for comments and review feedback. Address reviewer comments, push updates, and re-request review as needed. Continue polling until the PR is approved and merged, or closed. Never abandon a PR — see it through to resolution.
 
+After every push to a PR branch, review the current PR description (summary, layer-impact assessment, security design checklist, test plan) against the totality of changes in the PR. If any section no longer accurately reflects the implementation, update the PR description in the same operation — do not defer description updates to a later step.
+
 When receiving PR review feedback, always use `/receiving-code-review` before implementing suggestions.
 
 ### Conventional Commits


### PR DESCRIPTION
## Summary

- Adds guidance to PR Lifecycle section: after every push to a PR branch, review the PR description against the totality of changes and update it if any section no longer accurately reflects the implementation
- Prevents PR description drift identified in the #59 after-action report, where the description fell out of sync with the code at least three times during review

Closes #62

## Layer-Impact Assessment

No security layers affected. This is a documentation-only change to CLAUDE.md process guidance.

## Test Plan

- [x] Prettier formatting clean (`bunx prettier --check "**/*.{ts,md}"`)
- [x] Diff reviewed: single 2-line addition to PR Lifecycle section
- [x] Manual: Verify guidance is followed in subsequent PRs
