### PR TITLE
chore: pin subagent working directory to worktree path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,12 @@ All work — whether writing code, answering questions, or reviewing files — s
 
 All changes happen in git worktrees, never directly on main. Each worktree gets a descriptive branch name reflecting the change.
 
+**Subagent working directory discipline:** When dispatching subagents (implementation agents, panel review experts, or any Agent tool invocation that will modify files or commit):
+
+1. **Include the worktree absolute path** in every subagent task description. Subagents start with a fresh context and default to the repo root — they will commit to main unless explicitly directed elsewhere.
+2. **Require CWD verification before commits.** The subagent must confirm its working directory matches the intended worktree path before staging or committing any changes.
+3. **Consider `isolation: "worktree"`** on the Agent tool as an alternative. This gives each subagent its own isolated worktree and branch, preventing accidental commits to main. Use this when subagents work on independent tasks that don't need to build on each other's changes in a shared branch. Use a shared worktree (items 1–2) when subagents must coordinate sequential work on the same branch.
+
 ### PR-Based Integration
 
 Every change goes through a pull request — no direct commits to main. PR descriptions must include:


### PR DESCRIPTION
## Summary

Adds subagent working directory discipline guidance to CLAUDE.md's "Worktree-First Development" section, preventing subagents from accidentally committing to main instead of the active worktree.

- Require worktree absolute path in every subagent task description
- Require CWD verification before staging or committing
- Document `isolation: "worktree"` as an alternative strategy for independent tasks

Closes #55

## Layer-Impact Assessment

- **Affected layers:** None
- **Why:** Documentation-only change to CLAUDE.md's Git Workflow section. No security-layer key files, runtime behavior, or container configuration is modified.

## Panel Review

All four core panel experts approved without conditions:
1. **Container security specialist** — Approve. No runtime artifacts modified.
2. **Cloud infrastructure security engineer** — Approve. No security layer changes.
3. **Offensive security / red team analyst** — Approve. No new attack surface; tighter operational hygiene.
4. **Compliance and risk management advisor** — Approve. Proportionate fix for a process gap.

Full design comment: https://github.com/perezd/claudetainer/issues/55#issuecomment-4184835270

## Test Plan

- [x] Verify `bunx prettier --check "**/*.md"` passes
- [x] Verify diff contains only the intended 6-line addition to CLAUDE.md
- [x] Verify no other files are modified
