### PR TITLE
fix(docker): upgrade gopls pin from v0.18.1 to v0.21.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,8 +94,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g typescript typescript-language-server
 
-# gopls v0.18.1 (Go language server — pinned version)
-RUN GOBIN=/usr/local/go/bin GOPATH=/tmp/gobuild GOCACHE=/tmp/gobuild/cache go install golang.org/x/tools/gopls@v0.18.1 \
+# gopls v0.21.1 (Go language server — pinned version, requires Go 1.25+)
+RUN GOBIN=/usr/local/go/bin GOPATH=/tmp/gobuild GOCACHE=/tmp/gobuild/cache go install golang.org/x/tools/gopls@v0.21.1 \
     && rm -rf /tmp/gobuild
 
 # Cache-bust: everything below fetches "latest" and must be fresh each build.


### PR DESCRIPTION
## Summary

- Upgrade pinned gopls from v0.18.1 to v0.21.1 to fix Docker build failure under Go 1.26.2
- gopls v0.18.1 cannot compile against Go 1.26 due to internal `go/types` API changes
- v0.21.1 is the latest stable release (Feb 2026), requires Go 1.25+ which Go 1.26.2 satisfies

## Layer-Impact Assessment

**Affected layer:** Container Hardening (Dockerfile modification)
**Why:** Version bump of an existing pinned tool. Install path, permissions, cleanup, and build user are all unchanged.
**Other layers affected:** None

## Security Design Checklist

- **Trust anchor mutability:** N/A — version pinned at build time, immutable at runtime
- **File and output visibility:** N/A — same binary path (`/usr/local/go/bin/gopls`), same permissions, no secrets
- **Allowlist vs blocklist:** N/A — version pin, not a filter
- **Fail mode:** Build fails if install fails (fail-closed) — correct behavior
- **Temporal safety:** N/A — same RUN layer position, no privilege transitions changed
- **Network exposure:** N/A — gopls is a local LSP, no network changes
- **Layer compensation:** No layer weakened; install path, permissions, user, cleanup all identical

## Panel Review

All four core experts approved unanimously:

1. **Linux container security specialist** — Approve. No attack surface change, file permissions identical, build cleanup preserved, supply chain verified via Go sum database.
2. **Cloud infrastructure security engineer** — Approve. Build reproducibility maintained, no image bloat, no layer weakening.
3. **Offensive security / red team analyst** — Approve. No new capabilities, existing controls (UID 1000, read-only rootfs, default-deny network) unaffected.
4. **Compliance and risk management advisor** — Approve. Version pin maintained, change well-justified, comment updated with Go version requirement.

## Test Plan

- [ ] CI build completes successfully (the `docker/build-push-action` step that was failing)
- [ ] gopls binary is present at `/usr/local/go/bin/gopls` in the built image
