### PR TITLE
docs: add Stargate references across documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You (local machine)
 │  entrypoint.sh (PID 1, root)                        │
 │  ├── CoreDNS (domain allowlist DNS)                 │
 │  ├── iptables (OUTPUT DROP + IP allowlist)          │
+│  ├── Stargate (bash command classifier, localhost)  │
 │  ├── tmpfs mounts (/workspace, /home/claude, /tmp)  │
 │  ├── read-only root filesystem                      │
 │  └── start-claude → tmux session (at boot)          │

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,12 +11,13 @@ Internal reference for Codetainer's boot process, scripts, and file layouts.
 5. Generates CoreDNS config from domain allowlist, starts CoreDNS
 6. Applies iptables rules, starts 5-minute refresh loop
 7. Configures git identity, gh CLI auth, npm registry auth
-8. Copies Claude Code settings, skips onboarding wizard
-9. Remounts root filesystem read-only
-10. Clones `REPO_URL` if set
-11. Runs readiness checks
-12. Starts Claude Code in background (start-claude.sh — installs plugins, creates tmux session)
-13. Waits for SSH connections
+8. Generates Stargate config from template (patches scopes + telemetry), starts Stargate server as `claude` user
+9. Copies Claude Code settings, skips onboarding wizard
+10. Remounts root filesystem read-only
+11. Clones `REPO_URL` if set
+12. Runs readiness checks (CoreDNS, iptables, Stargate, settings, repo)
+13. Starts Claude Code in background (start-claude.sh — installs plugins, creates tmux session)
+14. Waits for SSH connections
 
 ## SSH Login Flow
 
@@ -33,9 +34,12 @@ codetainer/
 ├── network/                     # Network isolation layer
 │   ├── domains.conf             # Domain allowlist (one per line)
 │   └── Corefile.template        # CoreDNS base config (catch-all NXDOMAIN)
+├── stargate/                    # Stargate command control config
+│   └── stargate.toml            # Static config template (rules, scopes, classification policy)
 ├── scripts/                     # Runtime scripts (copied into container)
 │   ├── entrypoint.sh            # PID 1 boot script (see Boot Sequence)
 │   ├── start-claude.sh          # SSH login handler — tmux session manager
+│   ├── generate-stargate-config.sh  # Boot-time Stargate config from template + env vars
 │   ├── refresh-iptables.sh      # Resolves allowlisted domains → iptables rules
 │   ├── gh-wrapper.sh            # gh CLI wrapper ensuring GH_CONFIG_DIR is set
 │   ├── session-namer.sh         # Stop hook — renames tmux session via Haiku
@@ -57,16 +61,17 @@ codetainer/
 
 All scripts live in `scripts/` and are copied to `/usr/local/bin/` during the Docker build.
 
-| Script                      | Description                                                                                                                                                                                                                                                                          |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **`entrypoint.sh`**         | PID 1 boot script. Runs as root. Validates secrets, mounts tmpfs, starts CoreDNS, applies iptables, configures git/gh/npm auth, installs plugins, remounts rootfs read-only, clones the repo, and runs readiness checks. See [Boot Sequence](#boot-sequence) for the full order.     |
-| **`start-claude.sh`**       | Init-only boot script (invoked by `entrypoint.sh`). Acquires exclusive flock, waits for readiness, writes `CLAUDE_PROMPT` to temp file (if set), installs plugins, creates tmux session with Claude Code (top pane, 80%) and bash shell (bottom pane, 20%). Releases lock when done. |
-| **`attach-claude.sh`**      | SSH login handler (invoked by `.bashrc`). If a tmux session exists, attaches immediately. Otherwise, waits for `start-claude.sh` to complete via shared flock (5-min timeout), tailing the boot log for progress, then attaches.                                                     |
-| **`refresh-iptables.sh`**   | Resolves every domain in `network/domains.conf` to IPs via `dig`, builds an iptables ruleset with OUTPUT DROP default policy and ACCEPT rules for resolved IPs, then atomically applies it with `iptables-restore`. Called once at boot and every 5 minutes thereafter.              |
-| **`gh-wrapper.sh`**         | Thin wrapper around `/usr/bin/gh` that hardcodes `GH_CONFIG_DIR=/opt/gh-config`. Needed because Claude Code's subprocess chain can strip environment variables, which would break `gh` authentication. Installed as `/usr/local/bin/gh` to shadow the real binary.                   |
-| **`session-namer.sh`**      | Claude Code Stop hook. After the first assistant response in a session, sends the session context to Haiku to generate a short kebab-case name (e.g., `fixing-auth-bug`), then renames the tmux session. Uses a sentinel file to run only once per session.                          |
-| **`statusline-command.sh`** | Claude Code status line hook. Renders the current model name, a context window usage bar (color-coded green/yellow/red), and the tmux session name. Output appears in Claude Code's status line.                                                                                     |
-| **`status.sh`**             | Diagnostic tool available as the `status` command inside the container. Shows recent iptables drops (from dmesg) and CoreDNS process status.                                                                                                                                         |
+| Script                            | Description                                                                                                                                                                                                                                                                                                                                                                         |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`entrypoint.sh`**               | PID 1 boot script. Runs as root. Validates secrets, mounts tmpfs, starts CoreDNS, applies iptables, configures git/gh/npm auth, installs plugins, remounts rootfs read-only, clones the repo, and runs readiness checks. See [Boot Sequence](#boot-sequence) for the full order.                                                                                                    |
+| **`start-claude.sh`**             | Init-only boot script (invoked by `entrypoint.sh`). Acquires exclusive flock, waits for readiness, writes `CLAUDE_PROMPT` to temp file (if set), installs plugins, creates tmux session with Claude Code (top pane, 80%) and bash shell (bottom pane, 20%). Releases lock when done.                                                                                                |
+| **`attach-claude.sh`**            | SSH login handler (invoked by `.bashrc`). If a tmux session exists, attaches immediately. Otherwise, waits for `start-claude.sh` to complete via shared flock (5-min timeout), tailing the boot log for progress, then attaches.                                                                                                                                                    |
+| **`generate-stargate-config.sh`** | Boot-time config generator for Stargate. Copies the static template from `/opt/stargate/stargate.toml.template`, runs `stargate init` to create corpus/trace directories, then patches `github_owners` (from `REPO_URL`) and `allowed_domains` (from `domains.conf`). Optionally enables telemetry when Grafana env vars are set. Locks the final config to mode 444 on the rootfs. |
+| **`refresh-iptables.sh`**         | Resolves every domain in `network/domains.conf` to IPs via `dig`, builds an iptables ruleset with OUTPUT DROP default policy and ACCEPT rules for resolved IPs, then atomically applies it with `iptables-restore`. Called once at boot and every 5 minutes thereafter.                                                                                                             |
+| **`gh-wrapper.sh`**               | Thin wrapper around `/usr/bin/gh` that hardcodes `GH_CONFIG_DIR=/opt/gh-config`. Needed because Claude Code's subprocess chain can strip environment variables, which would break `gh` authentication. Installed as `/usr/local/bin/gh` to shadow the real binary.                                                                                                                  |
+| **`session-namer.sh`**            | Claude Code Stop hook. After the first assistant response in a session, sends the session context to Haiku to generate a short kebab-case name (e.g., `fixing-auth-bug`), then renames the tmux session. Uses a sentinel file to run only once per session.                                                                                                                         |
+| **`statusline-command.sh`**       | Claude Code status line hook. Renders the current model name, a context window usage bar (color-coded green/yellow/red), and the tmux session name. Output appears in Claude Code's status line.                                                                                                                                                                                    |
+| **`status.sh`**                   | Diagnostic tool available as the `status` command inside the container. Shows recent iptables drops (from dmesg) and CoreDNS process status.                                                                                                                                                                                                                                        |
 
 ## Container File Layout
 
@@ -76,6 +81,8 @@ All scripts live in `scripts/` and are copied to `/usr/local/bin/` during the Do
 ├── bun               # Bun runtime
 ├── bunx              # Bun package runner
 ├── coredns           # DNS server
+├── stargate          # Bash command classifier
+├── generate-stargate-config.sh  # Stargate config generator
 ├── fly               # Fly.io CLI
 ├── gh                # gh-wrapper.sh (shadows /usr/bin/gh)
 ├── attach-claude     # SSH attach gate (attach-claude.sh)
@@ -93,6 +100,9 @@ All scripts live in `scripts/` and are copied to `/usr/local/bin/` during the Do
 │   ├── settings.json        # Claude Code settings template
 │   ├── statusline-command.sh  # Status line hook
 │   └── session-namer.sh      # Session naming hook
+├── stargate/
+│   ├── stargate.toml.template  # Static config template (from repo)
+│   └── stargate.toml           # Generated config (patched at boot, mode 444)
 └── gh-config/               # Shared gh CLI config (created at runtime)
 
 /workspace/              # tmpfs, 512MB — working directory

--- a/docs/security.md
+++ b/docs/security.md
@@ -23,9 +23,18 @@ Codetainer enforces a three-layer security model. This document covers each laye
 - **5-minute refresh**: iptables rules are refreshed every 5 minutes to pick up IP changes
 - **IPv6 unrestricted**: Fly SSH requires public IPv6 routing, and Fly's kernel has broken IPv6 conntrack, so IPv6 output is left at ACCEPT. IPv4 iptables is the enforcement layer.
 
-## Layer 3: Command Control (Pending)
+## Layer 3: Command Control
 
-This layer is pending replacement by an external dependency. Previously provided by a built-in three-tier command classification pipeline. The Container Hardening and Network Isolation layers remain fully enforced.
+[Stargate](https://github.com/limbic-systems/stargate) classifies every Bash command before execution via Claude Code hooks:
+
+- **AST-based classification**: Commands are parsed into an AST and evaluated against configurable rules (RED/GREEN/YELLOW)
+- **Fail-closed**: If the Stargate server is unreachable, all Bash commands are blocked
+- **Scope-bound trust**: GitHub CLI operations and HTTP requests are evaluated against operator-defined scopes (`github_owners` derived from `REPO_URL`, `allowed_domains` derived from `network/domains.conf`)
+- **LLM review**: Ambiguous (YELLOW) commands are escalated to an LLM reviewer for semantic classification
+- **Immutable config**: The Stargate config (`stargate/stargate.toml`) is a static template shipped in the image, copied to the read-only rootfs at boot
+- **De-privileged**: The Stargate server runs as the `claude` user, not root
+
+See `stargate/stargate.toml` for the full rule set.
 
 ## Domain Allowlist
 


### PR DESCRIPTION
## Summary

Update documentation to reflect the restored Command Control layer (Stargate):

- `docs/security.md` — Replace "Layer 3: Pending" with full Stargate description (AST classification, fail-closed, scope-bound trust, LLM review, immutable config)
- `README.md` — Add Stargate to the ASCII process diagram
- `docs/architecture.md` — Update boot sequence (step 8), source repo layout (`stargate/` dir, `generate-stargate-config.sh`), scripts table, and container file layout (`/usr/local/bin/stargate`, `/opt/stargate/`)

## Test Plan

- [ ] Docs render correctly on GitHub
