### PR TITLE
feat(stargate): add GREEN rule for bunx prettier

### DIFF
--- a/stargate/stargate.toml
+++ b/stargate/stargate.toml
@@ -259,6 +259,11 @@ subcommands = ["test", "run", "build", "init"]
 reason = "Safe bun subcommands."
 
 [[rules.green]]
+command = "bunx"
+pattern = '^bunx\s+prettier\s'
+reason = "Prettier formatting via bunx."
+
+[[rules.green]]
 commands = ["tsc", "tsx"]
 reason = "TypeScript compiler and runner."
 


### PR DESCRIPTION
Adds a pattern-based GREEN rule matching `bunx prettier` specifically, so formatting commands don't trigger YELLOW review. Other `bunx` invocations remain YELLOW with LLM review.