### PR TITLE
chore(docker): bump stargate to v0.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,11 +79,11 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 # Stargate — bash command classifier for AI coding agents
 RUN ARCH=$(dpkg --print-architecture) && \
-    STARGATE_VERSION=v0.2.1 && \
+    STARGATE_VERSION=v0.2.2 && \
     if [ "$ARCH" = "amd64" ]; then \
-      STARGATE_SHA256="3d0e447681d266fbe98222dfa1deca2c2b6b92b757d524a81d24ab5da6ec1468"; \
+      STARGATE_SHA256="6da0c3c955a26b32b275694d9795611e2cefe842f09efb620d8b410af5157dd9"; \
     elif [ "$ARCH" = "arm64" ]; then \
-      STARGATE_SHA256="9446bda7c28cb7e3a4b64e5efc9818dbceaf812c5da8a51d4786ea6335a06926"; \
+      STARGATE_SHA256="b43c5cc216f2a1e4a1f26cc84c06de56d09b61570e25dc613a928402a64541ce"; \
     else \
       echo "Unsupported architecture: $ARCH" >&2; exit 1; \
     fi && \


### PR DESCRIPTION
## Summary

- Bump Stargate from v0.2.1 to v0.2.2
- Picks up limbic-systems/stargate#25: fixes `github_repo_owner` scope resolution in git worktrees

## Layer-Impact Assessment

| Layer | Affected | Justification |
|-------|----------|---------------|
| Container Hardening | No | No changes to user, rootfs, or tmpfs |
| Network Isolation | No | No domain or iptables changes |
| Command Control | **Yes** | Updated Stargate binary (bugfix only, no rule changes) |

The Stargate binary is verified via SHA256 checksum at build time. The update is a bugfix release — no new classification rules or behavioral changes beyond fixing scope resolution in worktrees.

## Test Plan

- [ ] Build container and verify Stargate starts successfully
- [ ] Verify `gh` commands in a git worktree are correctly classified against `github_owners` scope
