### PR TITLE
feat(stargate): add copilot-review GREEN rules and integrate upstream defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,11 +79,11 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 # Stargate — bash command classifier for AI coding agents
 RUN ARCH=$(dpkg --print-architecture) && \
-    STARGATE_VERSION=v0.2.2 && \
+    STARGATE_VERSION=v0.3.0 && \
     if [ "$ARCH" = "amd64" ]; then \
-      STARGATE_SHA256="6da0c3c955a26b32b275694d9795611e2cefe842f09efb620d8b410af5157dd9"; \
+      STARGATE_SHA256="f302b3257d5a020892c339ce635df040fee505b25083a3a203ddcf1f54b3b748"; \
     elif [ "$ARCH" = "arm64" ]; then \
-      STARGATE_SHA256="b43c5cc216f2a1e4a1f26cc84c06de56d09b61570e25dc613a928402a64541ce"; \
+      STARGATE_SHA256="012ca794bb736c01ce6d77a1c96b42d1ffdd780c7963ca1bdb790cbafdc75fd4"; \
     else \
       echo "Unsupported architecture: $ARCH" >&2; exit 1; \
     fi && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,11 +79,11 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 # Stargate — bash command classifier for AI coding agents
 RUN ARCH=$(dpkg --print-architecture) && \
-    STARGATE_VERSION=v0.3.0 && \
+    STARGATE_VERSION=v0.4.0 && \
     if [ "$ARCH" = "amd64" ]; then \
-      STARGATE_SHA256="f302b3257d5a020892c339ce635df040fee505b25083a3a203ddcf1f54b3b748"; \
+      STARGATE_SHA256="f2295faa00daa4cb0b0c9253e9f051caa41075f87e5f766744f9f8b7e347bf8b"; \
     elif [ "$ARCH" = "arm64" ]; then \
-      STARGATE_SHA256="012ca794bb736c01ce6d77a1c96b42d1ffdd780c7963ca1bdb790cbafdc75fd4"; \
+      STARGATE_SHA256="78045d299f8c3aebe70d70a173a242f702b1cb8be4f13b850352894da2379158"; \
     else \
       echo "Unsupported architecture: $ARCH" >&2; exit 1; \
     fi && \

--- a/stargate/stargate.toml
+++ b/stargate/stargate.toml
@@ -228,10 +228,21 @@ subcommands = ["add", "commit", "checkout", "switch", "merge", "rebase", "pull",
 reason = "Standard git workflow operations (force-push caught by RED rule above)."
 
 [[rules.green]]
+command = "git"
+subcommands = ["remote"]
+pattern = '^\s*git\s+remote\s+(get-url|show)\s'
+reason = "Read-only git remote queries (mutating remote ops caught by YELLOW rule)."
+
+[[rules.green]]
 commands = ["ls", "cat", "head", "tail", "wc", "sort", "uniq", "grep", "rg",
             "file", "stat", "du", "df", "which", "whereis", "type",
-            "true", "false", "test", "[", "find"]
-reason = "Read-only filesystem and text inspection utilities."
+            "true", "false", "test", "[", "find", "echo", "printf"]
+reason = "Read-only filesystem, text inspection, and output utilities."
+
+[[rules.green]]
+command = "sed"
+exclude_flags = ["-i", "--in-place"]
+reason = "Stream editor without in-place modification (sed -i caught by YELLOW rule with LLM review)."
 
 [[rules.green]]
 commands = ["cd", "pwd", "pushd", "popd", "dirs"]
@@ -298,8 +309,8 @@ commands = ["mkdir", "touch"]
 reason = "Directory and file creation."
 
 [[rules.green]]
-command = "bash"
-flags = ["-n"]
+commands = ["bash", "sh", "zsh", "dash"]
+flags = ["-n", "--noexec"]
 reason = "Syntax check only — parses but does not execute."
 
 # --- Copilot review skill scripts ---
@@ -391,11 +402,6 @@ command = "sed"
 flags = ["-i", "--in-place"]
 llm_review = true
 reason = "In-place file modification — LLM reviews the expression and target."
-
-[[rules.yellow]]
-command = "sed"
-llm_review = false
-reason = "Text stream editor — ask user (sed -i caught above with LLM review)."
 
 [[rules.yellow]]
 command = "tee"
@@ -521,13 +527,6 @@ reason = "Force-with-lease push — safer than --force but still rewrites remote
 commands = ["open", "xdg-open"]
 llm_review = true
 reason = "Opens URLs or files with default handlers — could launch phishing pages."
-
-# --- Misc ---
-
-[[rules.yellow]]
-commands = ["echo", "printf"]
-llm_review = false
-reason = "Output commands — ask user when used standalone (redirections handled by parser)."
 
 # ---------------------------------------------------------------------------
 # LLM Reviewer Configuration

--- a/stargate/stargate.toml
+++ b/stargate/stargate.toml
@@ -230,7 +230,7 @@ reason = "Standard git workflow operations (force-push caught by RED rule above)
 [[rules.green]]
 command = "git"
 subcommands = ["remote"]
-pattern = '^\s*git\s+remote\s+(get-url|show)\s'
+pattern = '^\s*git\s+remote\s+(get-url|show)($|\s)'
 reason = "Read-only git remote queries (mutating remote ops caught by YELLOW rule)."
 
 [[rules.green]]

--- a/stargate/stargate.toml
+++ b/stargate/stargate.toml
@@ -302,6 +302,18 @@ command = "bash"
 flags = ["-n"]
 reason = "Syntax check only — parses but does not execute."
 
+# --- Copilot review skill scripts ---
+
+[[rules.green]]
+command = "bash"
+pattern = '^bash\s+/home/claude/\.claude/skills/copilot-review/scripts/poll-copilot-review\.sh\s'
+reason = "Copilot review poll script — reads PR review status via gh API."
+
+[[rules.green]]
+command = "bash"
+pattern = '^bash\s+/home/claude/\.claude/skills/copilot-review/scripts/get-owner-repo\.sh\b'
+reason = "Copilot review helper — extracts owner/repo from git remote."
+
 # --- Scope-bound rules ---
 
 [[rules.green]]

--- a/stargate/stargate.toml
+++ b/stargate/stargate.toml
@@ -316,13 +316,11 @@ reason = "Syntax check only — parses but does not execute."
 # --- Copilot review skill scripts ---
 
 [[rules.green]]
-command = "bash"
-pattern = '^bash\s+/home/claude/\.claude/skills/copilot-review/scripts/poll-copilot-review\.sh\s'
+pattern = '^(bash\s+)?/home/claude/\.claude/skills/copilot-review/scripts/poll-copilot-review\.sh(\s|$)'
 reason = "Copilot review poll script — reads PR review status via gh API."
 
 [[rules.green]]
-command = "bash"
-pattern = '^bash\s+/home/claude/\.claude/skills/copilot-review/scripts/get-owner-repo\.sh\b'
+pattern = '^(bash\s+)?/home/claude/\.claude/skills/copilot-review/scripts/get-owner-repo\.sh($|\s)'
 reason = "Copilot review helper — extracts owner/repo from git remote."
 
 # --- Scope-bound rules ---


### PR DESCRIPTION
## Summary

- Bump stargate binary from v0.2.2 to v0.4.0
- Add GREEN rules for copilot-review skill scripts (`poll-copilot-review.sh`, `get-owner-repo.sh`)
- Integrate upstream Stargate defaults from [stargate PR #28](https://github.com/limbic-systems/stargate/pull/28):
  - GREEN: `git remote get-url/show` (read-only remote queries)
  - GREEN: `sed` without `-i` flag (using new `exclude_flags` feature)
  - GREEN: `echo`/`printf` promoted from YELLOW
  - GREEN: expanded shell syntax-check to `sh`/`zsh`/`dash` with `--noexec`
  - Removed dead YELLOW rules for `sed` catch-all and `echo`/`printf`

### Copilot review improvements

- Script rules now match both direct invocation and `bash`-prefixed forms (optional `(bash\s+)?` prefix)
- All regex terminators use `($|\s)` instead of `\s` or `\b` to correctly match commands with no trailing arguments
- `git remote show` (no args) now correctly matches the GREEN rule

The `exclude_flags` feature requires stargate v0.3.0+, which is included in this PR (v0.4.0).

Part of #78

## Layer-impact assessment

1. **Affected layer:** Command Control (Stargate)
2. **Why:** Adding new GREEN rules widens the set of commands that pass without LLM review. All additions are read-only operations or match upstream defaults. The `exclude_flags` feature adds a new classification mechanism that rejects matches when dangerous flags are present. Binary bump from v0.2.2→v0.4.0 picks up these features.
3. **Panel review:** Not triggered — these are upstream-aligned GREEN rule additions for known-safe operations plus a minor version bump of a trusted first-party binary. No new scripts, no credential handling, no network changes.

## Security design checklist

- **Trust anchor mutability:** The stargate.toml template is on read-only rootfs after boot (step 10). Config is generated at step 8 before rootfs remount. The stargate binary is installed at image build time, not runtime. Not writable at runtime.
- **File and output visibility:** No new files. stargate.toml contains no secrets. Binary is world-readable but immutable on read-only rootfs.
- **Allowlist vs blocklist:** Allowlist. Specific commands/patterns enumerated as GREEN. New commands require explicit rule additions.
- **Fail mode:** Fail-closed. Unmatched commands fall through to `default_decision = "yellow"` for LLM review.
- **Temporal safety:** N/A — static config template and binary both set at build time, patched at boot step 8 before agent starts at step 13.
- **Network exposure:** No new network exposure. Copilot-review scripts use `gh api` (already gated) and `git remote` (local).
- **Layer compensation:** Widens GREEN surface slightly. Container Hardening (read-only rootfs) and Network Isolation (domain allowlist) remain unchanged.

## Test plan

- [ ] Verify stargate.toml parses as valid TOML
- [ ] Verify GREEN patterns match intended commands (with and without `bash` prefix)
- [ ] Verify `exclude_flags` on `sed` rule correctly blocks `sed -i`
- [ ] Verify `git remote show` (no args) matches GREEN rule
- [ ] Deploy to test container with stargate v0.4.0
