### PR TITLE
fix(network): add release-assets.githubusercontent.com to domain allowlist

### DIFF
--- a/docs/accepted-risks.md
+++ b/docs/accepted-risks.md
@@ -121,6 +121,15 @@ Each entry includes: risk title, affected layer(s), why it can't be resolved, co
 - **Severity:** Low
 - **Date identified:** 2026-04-28 (identified during panel review of #78)
 
+### User-controlled content from githubusercontent domains
+
+- **Affected layer:** Network Isolation, Container Hardening
+- **Description:** Three `*.githubusercontent.com` domains are allowlisted: `raw.githubusercontent.com`, `objects.githubusercontent.com`, and `release-assets.githubusercontent.com`. All serve user-controlled content — any GitHub user can publish arbitrary files (source blobs, release binaries, raw file content) that can be downloaded into the container's writable tmpfs (`/workspace`, `/home/claude`, `/tmp`). `GH_PAT` is transmitted in request headers over HTTPS to these domains.
+- **Why it can't be resolved:** These domains are required for core GitHub workflows: raw file access, git object storage, and release asset downloads. Blocking them would break `gh`, `git clone`, and `gh release download`.
+- **Compensating controls:** Container runs as non-root UID 1000 with size-limited tmpfs (ephemeral, no persistence across sessions). Stargate command classification gates execution of downloaded content. TLS protects `GH_PAT` in transit. Network isolation limits where downloaded content or exfiltrated data can be sent.
+- **Severity:** Medium
+- **Date identified:** 2026-04-29 (pre-existing risk, formally documented during panel review of #92)
+
 ---
 
 ## Resolved Risks

--- a/docs/accepted-risks.md
+++ b/docs/accepted-risks.md
@@ -124,9 +124,9 @@ Each entry includes: risk title, affected layer(s), why it can't be resolved, co
 ### User-controlled content from githubusercontent domains
 
 - **Affected layer:** Network Isolation, Container Hardening
-- **Description:** Three `*.githubusercontent.com` domains are allowlisted: `raw.githubusercontent.com`, `objects.githubusercontent.com`, and `release-assets.githubusercontent.com`. All serve user-controlled content — any GitHub user can publish arbitrary files (source blobs, release binaries, raw file content) that can be downloaded into the container's writable tmpfs (`/workspace`, `/home/claude`, `/tmp`). `GH_PAT` is transmitted in request headers over HTTPS to these domains.
+- **Description:** Three specific subdomains of `githubusercontent.com` are individually allowlisted: `raw.githubusercontent.com`, `objects.githubusercontent.com`, and `release-assets.githubusercontent.com`. All serve user-controlled content — any GitHub user can publish arbitrary files (source blobs, release binaries, raw file content) that can be downloaded into the container's writable tmpfs (`/workspace`, `/home/claude`, `/tmp`). `GH_PAT` is used for GitHub API authentication; downloads from these CDN domains typically use short-lived signed URLs obtained via API redirect rather than direct PAT transmission.
 - **Why it can't be resolved:** These domains are required for core GitHub workflows: raw file access, git object storage, and release asset downloads. Blocking them would break `gh`, `git clone`, and `gh release download`.
-- **Compensating controls:** Container runs as non-root UID 1000 with size-limited tmpfs (ephemeral, no persistence across sessions). Stargate command classification gates execution of downloaded content. TLS protects `GH_PAT` in transit. Network isolation limits where downloaded content or exfiltrated data can be sent.
+- **Compensating controls:** Container runs as non-root UID 1000 with size-limited tmpfs (ephemeral, no persistence across sessions). Stargate command classification gates execution of downloaded content. HTTPS/TLS protects all traffic in transit. Network isolation limits where downloaded content or exfiltrated data can be sent.
 - **Severity:** Medium
 - **Date identified:** 2026-04-29 (pre-existing risk, formally documented during panel review of #92)
 

--- a/network/domains.conf
+++ b/network/domains.conf
@@ -11,6 +11,7 @@ github.com
 api.github.com
 api.githubcopilot.com
 objects.githubusercontent.com
+release-assets.githubusercontent.com
 
 # Package registries
 registry.npmjs.org


### PR DESCRIPTION
## Summary

- Add `release-assets.githubusercontent.com` to `network/domains.conf` in the GitHub section, unblocking `gh release download` inside the container
- Document the pre-existing accepted risk of user-controlled content from `*.githubusercontent.com` domains in `docs/accepted-risks.md`

## Layer-Impact Assessment

**Affected layer:** Network Isolation

**Why:** Expands the domain allowlist by one entry. Default-deny posture (CoreDNS NXDOMAIN + iptables OUTPUT DROP) is unchanged. The new domain is GitHub's Fastly-backed CDN for release binaries — same infrastructure as the already-allowed `objects.githubusercontent.com`.

**Panel review:** Full panel review completed with 5 experts (3 unconditional approves, 2 approve-with-conditions). Conditions addressed: (1) acknowledged attacker-controlled content in security design checklist, (2) noted `GH_PAT` traversal with TLS protection. Design comment posted to issue.

## Security Design Checklist

- **Trust anchor mutability:** No. `domains.conf` is baked into the image, rootfs read-only at boot.
- **File and output visibility:** Downloaded release assets are attacker-controlled content landing in writable tmpfs. `GH_PAT` traverses this domain over HTTPS; TLS is the credential-protection control.
- **Allowlist vs blocklist:** Allowlist — one explicit domain added to enumerated list.
- **Fail mode:** Unchanged. Default-deny intact on both layers.
- **Temporal safety:** No change to boot sequence or privilege transitions.
- **Network exposure:** One new outbound destination (GitHub release asset CDN). Metadata IPs blocked.
- **Layer compensation:** No layer weakened.

## Test Plan

- [ ] Verify `gh release download` works for repos within `github_owners` scope after container rebuild
- [ ] Verify CoreDNS resolves `release-assets.githubusercontent.com` (not NXDOMAIN)
- [ ] Verify iptables ACCEPT rules include resolved IPs for the new domain

Closes #92
