### PR TITLE
feat(policies): add label-based routing to issue-driven workflow

### DIFF
--- a/skills/issue-driven-workflow/SKILL.md
+++ b/skills/issue-driven-workflow/SKILL.md
@@ -48,8 +48,8 @@ digraph issue_driven {
     route_check -> debug [label="bug / regression\n/ defect"];
     route_check -> brainstorm [label="enhancement\n/ feature"];
     route_check -> desc_fallback [label="no recognized\nlabel"];
-    desc_fallback -> debug [label="bug-like\nlanguage"];
-    desc_fallback -> brainstorm [label="otherwise"];
+    desc_fallback -> debug [label="unclear /\ninconclusive"];
+    desc_fallback -> brainstorm [label="clearly not\nbug-like"];
     debug -> brainstorm;
     brainstorm -> design;
     design -> panel;

--- a/skills/issue-driven-workflow/SKILL.md
+++ b/skills/issue-driven-workflow/SKILL.md
@@ -81,7 +81,7 @@ digraph issue_driven {
    - `ISSUE_NUMBER` — the issue number
    - `OWNER_REPO` — `owner/repo` from the URL
    - `ISSUE_URL` — the full GitHub URL
-   - `ISSUE_LABELS` — label names (used for bug triage gate)
+   - `ISSUE_LABELS` — label names (used for label-based routing)
 3. Route the issue using label-based routing (see Issue Routing below). Extract label names and match against the routing table. If no recognized label matches, fall back to description-based heuristic.
 
 ## Issue Routing

--- a/skills/issue-driven-workflow/SKILL.md
+++ b/skills/issue-driven-workflow/SKILL.md
@@ -96,10 +96,10 @@ After activation, route to the appropriate skill based on issue labels. Labels a
 **Evaluation order:**
 
 1. Extract label names from the fetched issue metadata.
-2. Match labels against the routing table (case-insensitive). First match wins — if an issue has both `bug` and `enhancement` labels, `bug` takes precedence.
-3. If no recognized label matches, fall back to description-based heuristic: analyze the issue title and body for bug-like language (e.g., "broken", "error", "fails", "unexpected"). If it looks like a bug, route to `/systematic-debugging`. Otherwise, default to `/brainstorming`.
+2. Evaluate the routing table rows in the order shown above (case-insensitive label matching). Issue label ordering is not significant. The first routing-table row with any matching label determines the skill, so bug-class labels (`bug`, `regression`, `defect`) take precedence over enhancement-class labels (`enhancement`, `feature`) on multi-label issues.
+3. If no routing-table row matches any issue label, fall back to the description-based heuristic: analyze the issue title and body for bug-like language (e.g., "broken", "error", "fails", "unexpected"). If it clearly looks like a bug, route to `/systematic-debugging`. If the description is unclear or inconclusive, also route to `/systematic-debugging`. Only default to `/brainstorming` when the description is clearly not bug-like.
 
-**When ambiguous** (no labels, description is unclear), default to treating the issue as a bug. It is lower cost to debug unnecessarily than to skip root-cause analysis on a real defect.
+**When ambiguous** (no labels, description is unclear or inconclusive), default to treating the issue as a bug and route to `/systematic-debugging`. It is lower cost to debug unnecessarily than to skip root-cause analysis on a real defect.
 
 ## Comment Sequence
 

--- a/skills/issue-driven-workflow/SKILL.md
+++ b/skills/issue-driven-workflow/SKILL.md
@@ -26,7 +26,8 @@ digraph issue_driven {
     rankdir=TB;
 
     activate [label="Activation\n(fetch issue, extract metadata)" shape=box];
-    bug_check [label="Bug / regression?" shape=diamond];
+    route_check [label="Check labels\n(routing table)" shape=diamond];
+    desc_fallback [label="Description\nheuristic" shape=diamond];
     debug [label="Systematic debugging\n(/systematic-debugging)" shape=box];
     brainstorm [label="Brainstorming\n(/brainstorming)" shape=box];
     design [label="Write design spec" shape=box];
@@ -43,9 +44,12 @@ digraph issue_driven {
     aar [label="Post AAR comment\nto issue" shape=box];
     done [label="Done" shape=doublecircle];
 
-    activate -> bug_check;
-    bug_check -> debug [label="yes"];
-    bug_check -> brainstorm [label="no"];
+    activate -> route_check;
+    route_check -> debug [label="bug / regression\n/ defect"];
+    route_check -> brainstorm [label="enhancement\n/ feature"];
+    route_check -> desc_fallback [label="no recognized\nlabel"];
+    desc_fallback -> debug [label="bug-like\nlanguage"];
+    desc_fallback -> brainstorm [label="otherwise"];
     debug -> brainstorm;
     brainstorm -> design;
     design -> panel;
@@ -78,16 +82,24 @@ digraph issue_driven {
    - `OWNER_REPO` — `owner/repo` from the URL
    - `ISSUE_URL` — the full GitHub URL
    - `ISSUE_LABELS` — label names (used for bug triage gate)
-3. Determine issue type: check labels for `bug`, `regression`, `defect`, or similar. If labels are absent, analyze the issue title and body for bug-like language (e.g., "broken", "error", "fails", "unexpected").
+3. Route the issue using label-based routing (see Issue Routing below). Extract label names and match against the routing table. If no recognized label matches, fall back to description-based heuristic.
 
-## Bug Triage Gate
+## Issue Routing
 
-If the issue is a bug, regression, or report of unexpected behavior (by label or description):
+After activation, route to the appropriate skill based on issue labels. Labels are the authoritative signal; description analysis is the fallback.
 
-1. Invoke `/systematic-debugging` **before** `/brainstorming`.
-2. Identify the root cause first, then design the fix.
+| Label                         | Skill                   | Effect                                                          |
+| ----------------------------- | ----------------------- | --------------------------------------------------------------- |
+| `bug`, `regression`, `defect` | `/systematic-debugging` | Invoke before `/brainstorming` — root-cause analysis first      |
+| `enhancement`, `feature`      | `/brainstorming`        | Invoke directly — skip debugging, start with design exploration |
 
-**When ambiguous**, default to treating the issue as a bug. It is lower cost to debug unnecessarily than to skip root-cause analysis on a real defect.
+**Evaluation order:**
+
+1. Extract label names from the fetched issue metadata.
+2. Match labels against the routing table (case-insensitive). First match wins — if an issue has both `bug` and `enhancement` labels, `bug` takes precedence.
+3. If no recognized label matches, fall back to description-based heuristic: analyze the issue title and body for bug-like language (e.g., "broken", "error", "fails", "unexpected"). If it looks like a bug, route to `/systematic-debugging`. Otherwise, default to `/brainstorming`.
+
+**When ambiguous** (no labels, description is unclear), default to treating the issue as a bug. It is lower cost to debug unnecessarily than to skip root-cause analysis on a real defect.
 
 ## Comment Sequence
 

--- a/user-claude-md/user-policies.md
+++ b/user-claude-md/user-policies.md
@@ -125,8 +125,10 @@ After fetching issue metadata, route to the appropriate skill based on issue lab
 **Evaluation order:**
 
 1. Extract label names from the fetched issue metadata.
-2. Match labels against the routing table (case-insensitive). First match wins — if an issue has both `bug` and `enhancement` labels, `bug` takes precedence.
-3. If no recognized label matches, fall back to description-based heuristic: analyze the issue title and body for bug-like language (e.g., "broken", "error", "fails", "unexpected"). If it looks like a bug, route to `/systematic-debugging`. Otherwise, default to `/brainstorming`.
+2. Evaluate the routing table rows in the order shown above (case-insensitive label matching). Issue label ordering is not significant. The first routing-table row with any matching label determines the skill, so bug-class labels (`bug`, `regression`, `defect`) take precedence over enhancement-class labels (`enhancement`, `feature`) on multi-label issues.
+3. If no routing-table row matches any issue label, fall back to the description-based heuristic: analyze the issue title and body for bug-like language (e.g., "broken", "error", "fails", "unexpected"). If it clearly looks like a bug, route to `/systematic-debugging`. If the description is unclear or inconclusive, also route to `/systematic-debugging`. Only default to `/brainstorming` when the description is clearly not bug-like.
+
+**When ambiguous** (no labels, description is unclear or inconclusive), default to treating the issue as a bug and route to `/systematic-debugging`. It is lower cost to debug unnecessarily than to skip root-cause analysis on a real defect.
 
 ### Additional Overrides
 

--- a/user-claude-md/user-policies.md
+++ b/user-claude-md/user-policies.md
@@ -113,12 +113,28 @@ When dispatching subagents that modify TypeScript or Markdown files, include an 
 
 When the user provides a full GitHub issue URL, or a shorthand issue reference (e.g., `#24`, `owner/repo#24`) with explicit context confirming it is the work target, invoke the `/issue-driven-workflow` skill. Do not infer an originating issue from branch names, commit messages, or other indirect context. An issue number mentioned only as background or comparison is not sufficient to activate the skill.
 
+### Label-Based Routing
+
+After fetching issue metadata, route to the appropriate skill based on issue labels. Labels are the authoritative signal; description analysis is the fallback.
+
+| Label                         | Skill                   | Effect                                                          |
+| ----------------------------- | ----------------------- | --------------------------------------------------------------- |
+| `bug`, `regression`, `defect` | `/systematic-debugging` | Invoke before `/brainstorming` — root-cause analysis first      |
+| `enhancement`, `feature`      | `/brainstorming`        | Invoke directly — skip debugging, start with design exploration |
+
+**Evaluation order:**
+
+1. Extract label names from the fetched issue metadata.
+2. Match labels against the routing table (case-insensitive). First match wins — if an issue has both `bug` and `enhancement` labels, `bug` takes precedence.
+3. If no recognized label matches, fall back to description-based heuristic: analyze the issue title and body for bug-like language (e.g., "broken", "error", "fails", "unexpected"). If it looks like a bug, route to `/systematic-debugging`. Otherwise, default to `/brainstorming`.
+
+### Additional Overrides
+
 Evaluate these overrides **before invoking any skill**. These take precedence over skill-default behaviors.
 
-1. **Bug triage order** — If the issue is a bug, regression, or report of unexpected behavior (by label or description), invoke `/systematic-debugging` before proceeding with `/brainstorming` and `/writing-plans`. Do not skip this even if the fix seems obvious.
-2. **Artifact routing** — Design specs and implementation plans are posted as comments on the originating issue, not written to local files. Skill defaults for file output paths (`docs/superpowers/specs/`, `docs/superpowers/plans/`) do not apply.
-3. **Panel review gate** — The design comment must complete full panel review with all experts signing off before being posted to the issue.
-4. **Continuous flow** — If the user has explicitly said to continue (e.g., "looks good continue", "proceed", "keep going"), transition through brainstorming → writing-plans → execution without pausing for additional confirmation at each phase boundary. The user's instruction to continue carries forward.
+1. **Artifact routing** — Design specs and implementation plans are posted as comments on the originating issue, not written to local files. Skill defaults for file output paths (`docs/superpowers/specs/`, `docs/superpowers/plans/`) do not apply.
+2. **Panel review gate** — The design comment must complete full panel review with all experts signing off before being posted to the issue.
+3. **Continuous flow** — If the user has explicitly said to continue (e.g., "looks good continue", "proceed", "keep going"), transition through brainstorming → writing-plans → execution without pausing for additional confirmation at each phase boundary. The user's instruction to continue carries forward.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaces the single "Bug triage order" override in the Issue-Driven Workflow Gate with a structured **label-based routing** mechanism that maps issue labels to skills
- Adds explicit routing for `enhancement`/`feature` labels → `/brainstorming` alongside the existing `bug`/`regression`/`defect` → `/systematic-debugging` path
- Labels are the authoritative signal; description-based heuristic is retained as a fallback for unlabeled issues

## Layer-Impact Assessment

**Security layers affected:** None. This change modifies behavioral policy documents only — no security-layer files, no scripts, no network configuration, no credential handling. No panel review triggered.

## Changes

### `user-claude-md/user-policies.md`

- Replaced override item 1 ("Bug triage order") with a "Label-Based Routing" subsection containing a routing table and evaluation order
- Renumbered remaining overrides 2–4 to 1–3 under a new "Additional Overrides" heading

### `skills/issue-driven-workflow/SKILL.md`

- Renamed "Bug Triage Gate" section to "Issue Routing" with routing table and evaluation order
- Updated flow diagram: `bug_check` diamond → `route_check` diamond with three edges (bug labels, enhancement labels, no match) plus a `desc_fallback` diamond
- Updated Activation step 3 to reference the new routing table
- Fixed stale "bug triage gate" reference in `ISSUE_LABELS` comment

## Test Plan

- [ ] Verify routing table is consistent between both files
- [ ] Verify flow diagram has three outgoing edges from `route_check` plus fallback path
- [ ] Verify Prettier passes on both modified files
- [ ] Verify remaining overrides are correctly renumbered (1–3, not 1–4)
