### PR TITLE
fix(stargate): add missing llm, scrubbing, and telemetry config values

### DIFF
--- a/scripts/generate-stargate-config.sh
+++ b/scripts/generate-stargate-config.sh
@@ -64,6 +64,15 @@ if [[ -n "${GRAFANA_INSTANCE_ID:-}" ]] && [[ -n "${GRAFANA_API_TOKEN:-}" ]] && [
     sed -i "/^\[telemetry\]/a endpoint = \"${GRAFANA_OTLP_ENDPOINT}\"" "$STARGATE_CONFIG"
 fi
 
+# Patch service_name from FLY_APP_NAME (for per-app telemetry grouping)
+if [[ -n "${FLY_APP_NAME:-}" ]]; then
+    if [[ "${FLY_APP_NAME}" =~ ^[a-z0-9-]+$ ]]; then
+        sed -i "s|^service_name = .*|service_name = \"${FLY_APP_NAME}\"|" "$STARGATE_CONFIG"
+    else
+        echo "[STARGATE] WARN: FLY_APP_NAME failed validation, using default service_name" >&2
+    fi
+fi
+
 # === 9. Lock permissions ===
 chmod 444 "$STARGATE_CONFIG"
 

--- a/scripts/generate-stargate-config.sh
+++ b/scripts/generate-stargate-config.sh
@@ -66,8 +66,10 @@ fi
 
 # Patch service_name from FLY_APP_NAME (for per-app telemetry grouping)
 if [[ -n "${FLY_APP_NAME:-}" ]]; then
-    if [[ "${FLY_APP_NAME}" =~ ^[a-z0-9-]+$ ]]; then
-        sed -i "s|^service_name = .*|service_name = \"${FLY_APP_NAME}\"|" "$STARGATE_CONFIG"
+    if [[ "${FLY_APP_NAME}" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
+        sed -i '/^\[telemetry\]/,/^$/{
+            s|^service_name = .*|service_name = "'"${FLY_APP_NAME}"'"|
+        }' "$STARGATE_CONFIG"
     else
         echo "[STARGATE] WARN: FLY_APP_NAME failed validation, using default service_name" >&2
     fi

--- a/stargate/stargate.toml
+++ b/stargate/stargate.toml
@@ -565,6 +565,7 @@ denied_paths = [
 extra_patterns = [
   'sk-ant-[a-zA-Z0-9_-]+',
   'AKIA[A-Z0-9]{16}',
+  'ASIA[A-Z0-9]{16}',
   'ghp_[a-zA-Z0-9]{36}',
   'github_pat_[a-zA-Z0-9_]+',
   'gho_[a-zA-Z0-9]{36}',

--- a/stargate/stargate.toml
+++ b/stargate/stargate.toml
@@ -563,6 +563,7 @@ denied_paths = [
 
 [scrubbing]
 extra_patterns = [
+  'sk-ant-[a-zA-Z0-9_-]+',
   'AKIA[A-Z0-9]{16}',
   'ghp_[a-zA-Z0-9]{36}',
   'github_pat_[a-zA-Z0-9_]+',

--- a/stargate/stargate.toml
+++ b/stargate/stargate.toml
@@ -536,12 +536,40 @@ reason = "Opens URLs or files with default handlers — could launch phishing pa
 #   2. CLAUDE_CODE_OAUTH_TOKEN + claude binary on PATH → subprocess via claude -p
 # If neither is set, LLM review is disabled (all llm_review commands
 # fall through to YELLOW/ask user).
+#
+# File retrieval sends workspace file contents to the Anthropic API for
+# command classification, independently of Claude Code's own API calls.
+model = "claude-sonnet-4-6"
+max_tokens = 512
+max_response_reasoning_length = 200
+temperature = 0.0
+allow_file_retrieval = true
+max_file_size = 65536
+allowed_paths = ["/workspace/**"]
+denied_paths = [
+  "**/.env", "**/.env.*",
+  "**/*secret*", "**/*token*", "**/*credential*",
+  "**/id_rsa", "**/id_ed25519", "**/*.pem", "**/*.key",
+  "**/*.p12", "**/*.pfx", "**/*.jks",
+  "**/.git/config",
+  "**/.npmrc", "**/.pypirc", "**/.netrc",
+  "**/.docker/config.json",
+  "**/service-account*.json",
+]
 
 # ---------------------------------------------------------------------------
 # Secret Scrubbing
 # ---------------------------------------------------------------------------
 
 [scrubbing]
+extra_patterns = [
+  'AKIA[A-Z0-9]{16}',
+  'ghp_[a-zA-Z0-9]{36}',
+  'github_pat_[a-zA-Z0-9_]+',
+  'gho_[a-zA-Z0-9]{36}',
+  'npm_[a-zA-Z0-9]+',
+  'pypi-[a-zA-Z0-9]+',
+]
 
 # ---------------------------------------------------------------------------
 # Precedent Corpus
@@ -558,6 +586,11 @@ reason = "Opens URLs or files with default handlers — could launch phishing pa
 
 [telemetry]
 enabled = false
+protocol = "http/protobuf"
+service_name = "stargate"
+export_logs = true
+export_metrics = true
+export_traces = true
 
 # ---------------------------------------------------------------------------
 # Local Logging


### PR DESCRIPTION
## Summary

- Add missing `[llm]` section values (model, max_tokens, max_response_reasoning_length, temperature, file retrieval with absolute-path scoping and credential file exclusions) that fix broken LLM classification due to Go zero-value defaults
- Add `[scrubbing]` extra patterns for Anthropic API keys, GitHub PATs, AWS access keys (long-term and STS), npm tokens, and PyPI tokens as defense-in-depth credential redaction
- Add `[telemetry]` static fields (protocol, service_name, export flags) and parameterize `service_name` from `FLY_APP_NAME` with regex validation for per-app telemetry grouping

## Layer-Impact Assessment

- **Container Hardening:** Not affected
- **Network Isolation:** Not affected
- **Command Control:** Strengthened — LLM classification now functions correctly; `denied_paths` prevents credential file content in LLM prompts; `extra_patterns` catches credential values by format

## Security Design Checklist

- **Trust anchor mutability:** Static template values, mode 444 config, read-only rootfs after step 10. `FLY_APP_NAME` is infrastructure-set with regex validation. No runtime mutability.
- **File and output visibility:** Config contains no credentials (auth via env vars only). `service_name` receives non-sensitive `FLY_APP_NAME`. File retrieval data channel documented via template comment.
- **Allowlist vs blocklist:** `allowed_paths = ["/workspace/**"]` is absolute-path allowlist. `denied_paths` is defense-in-depth within workspace. `extra_patterns` is content-based scrubbing as third layer.
- **Fail mode:** LLM failure → YELLOW/ask-user (fail-closed). `FLY_APP_NAME` validation failure → template default (fail-safe). `denied_paths` miss → scrubbing layer + trusted API endpoint.
- **Temporal safety:** Config at step 8, stargate at step 9, rootfs lock at step 10. No TOCTOU.
- **Network exposure:** No new paths. LLM calls use existing Anthropic API path.
- **Layer compensation:** Strengthens Command Control. No layer weakened.

## Panel Review

All 5 experts approved (2 rounds). Key changes from Round 1 feedback:
- `allowed_paths` changed from `./**` to `/workspace/**` (stargate inherits entrypoint CWD `/`)
- `denied_paths` expanded with .npmrc, .netrc, .pypirc, keystores, Docker/GCP configs
- GitHub PAT patterns added to `extra_patterns`
- `FLY_APP_NAME` regex validation added

## Test Plan

- [x] TOML parses correctly (verified via `tomllib.load()`)
- [x] All `[llm]` values match design
- [x] All `[scrubbing]` patterns present (8 patterns: Anthropic, AWS AKIA/ASIA, GitHub PATs x3, npm, PyPI)
- [x] All `[telemetry]` static fields present
- [x] `FLY_APP_NAME` validation with `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$` in generator script
- [ ] Deploy to staging and verify stargate starts with new config
- [ ] Verify LLM classification works for YELLOW commands

Closes #100
