### PR TITLE
feat(stargate): upgrade to v0.5.0 and rebuild config from upstream defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,11 +79,11 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 # Stargate — bash command classifier for AI coding agents
 RUN ARCH=$(dpkg --print-architecture) && \
-    STARGATE_VERSION=v0.4.0 && \
+    STARGATE_VERSION=v0.5.0 && \
     if [ "$ARCH" = "amd64" ]; then \
-      STARGATE_SHA256="f2295faa00daa4cb0b0c9253e9f051caa41075f87e5f766744f9f8b7e347bf8b"; \
+      STARGATE_SHA256="abf5e6cdd9eaa39a430ce68dd1212ce584e57c8727747dfafb96800d5b7888b9"; \
     elif [ "$ARCH" = "arm64" ]; then \
-      STARGATE_SHA256="78045d299f8c3aebe70d70a173a242f702b1cb8be4f13b850352894da2379158"; \
+      STARGATE_SHA256="90bfee6a23788390c3e49753f5018cd045bdb7157383dd6b1739d1716711110b"; \
     else \
       echo "Unsupported architecture: $ARCH" >&2; exit 1; \
     fi && \

--- a/stargate/stargate.toml
+++ b/stargate/stargate.toml
@@ -7,13 +7,18 @@
 
 [server]
 listen = "127.0.0.1:9099"
+# timeout = "10s"
 
 [parser]
 dialect = "bash"
+# resolve_aliases = false
 
 [classifier]
 default_decision = "yellow"
+# default_llm_review = true
 unresolvable_expansion = "yellow"
+# max_ast_depth = 64
+# max_command_length = 65536
 
 # ---------------------------------------------------------------------------
 # Scopes — Operator-defined trust boundaries
@@ -176,6 +181,12 @@ commands = ["base64", "xxd", "openssl"]
 context = "pipeline_sink"
 reason = "Encoded payload execution patterns."
 
+# --- Guardrail introspection ---
+
+[[rules.red]]
+command = "stargate"
+reason = "Agents must not introspect their own guardrails. Debug stargate via SSH, not through the agent."
+
 # --- Process tracing ---
 
 [[rules.red]]
@@ -197,12 +208,6 @@ command = "docker"
 subcommands = ["run"]
 flags = ["--privileged"]
 reason = "Privileged container — full host access."
-
-# --- Guardrail introspection ---
-
-[[rules.red]]
-command = "stargate"
-reason = "Agents must not introspect their own guardrails."
 
 # --- Codetainer-specific: credential file protection ---
 
@@ -227,6 +232,8 @@ command = "git"
 subcommands = ["add", "commit", "checkout", "switch", "merge", "rebase", "pull", "push", "worktree"]
 reason = "Standard git workflow operations (force-push caught by RED rule above)."
 
+# --- Codetainer-specific: read-only git remote queries ---
+
 [[rules.green]]
 command = "git"
 subcommands = ["remote"]
@@ -243,6 +250,11 @@ reason = "Read-only filesystem, text inspection, and output utilities."
 command = "sed"
 exclude_flags = ["-i", "--in-place"]
 reason = "Stream editor without in-place modification (sed -i caught by YELLOW rule with LLM review)."
+
+[[rules.green]]
+commands = ["bash", "sh", "zsh", "dash"]
+flags = ["-n", "--noexec"]
+reason = "Shell syntax check only — parses but never executes."
 
 [[rules.green]]
 commands = ["cd", "pwd", "pushd", "popd", "dirs"]
@@ -268,6 +280,8 @@ reason = "Safe npm subcommands."
 command = "bun"
 subcommands = ["test", "run", "build", "init"]
 reason = "Safe bun subcommands."
+
+# --- Codetainer-specific: bunx prettier ---
 
 [[rules.green]]
 command = "bunx"
@@ -301,19 +315,14 @@ subcommands = ["ps", "images", "logs", "inspect", "stats", "top", "port"]
 reason = "Read-only Docker operations."
 
 [[rules.green]]
-commands = ["date", "cal", "printenv", "uname", "hostname", "id", "whoami"]
+commands = ["date", "cal", "uname", "hostname", "id", "whoami"]
 reason = "System info queries (read-only)."
 
 [[rules.green]]
 commands = ["mkdir", "touch"]
 reason = "Directory and file creation."
 
-[[rules.green]]
-commands = ["bash", "sh", "zsh", "dash"]
-flags = ["-n", "--noexec"]
-reason = "Syntax check only — parses but does not execute."
-
-# --- Copilot review skill scripts ---
+# --- Codetainer-specific: copilot review skill scripts ---
 
 [[rules.green]]
 pattern = '^(bash\s+)?/home/claude/\.claude/skills/copilot-review/scripts/poll-copilot-review\.sh(\s|$)'
@@ -481,6 +490,11 @@ reason = "Trap handlers execute strings as commands."
 command = "env"
 llm_review = true
 reason = "env can execute commands and modify environment (PATH, LD_PRELOAD)."
+
+[[rules.yellow]]
+command = "printenv"
+llm_review = true
+reason = "printenv reveals environment variable values and can expose secrets; the no-argument form is especially risky as it dumps the full environment."
 
 [[rules.yellow]]
 commands = ["export", "unset"]

--- a/stargate/stargate.toml
+++ b/stargate/stargate.toml
@@ -216,6 +216,12 @@ command = "cat"
 args = ["/opt/gh-config/.ghtoken", "/opt/gh-config/*"]
 reason = "Direct read of credential file."
 
+# --- Codetainer-specific: process environment file protection ---
+
+[[rules.red]]
+pattern = '/proc/[0-9a-z]*/environ'
+reason = "Reading process environment files exposes all env vars including credentials."
+
 # === GREEN Rules (always allow) ===========================================
 
 [[rules.green]]
@@ -285,7 +291,7 @@ reason = "Safe bun subcommands."
 
 [[rules.green]]
 command = "bunx"
-pattern = '^bunx\s+prettier\s'
+pattern = '^bunx\s+prettier(\s|$)'
 reason = "Prettier formatting via bunx."
 
 [[rules.green]]


### PR DESCRIPTION
## Summary

- Bump Stargate binary from v0.4.0 to v0.5.0 with verified SHA256 checksums
- Rebuild `stargate.toml` template from upstream `default-stargate.toml` (v0.5.0) as the structural base, with all codetainer-specific customizations layered on top
- Fix `printenv` classification: GREEN → YELLOW with LLM review (upstream PR #39 — secret exposure risk)

## Upstream Changes (v0.4.0 → v0.5.0)

| PR | Change | Impact |
|---|---|---|
| #32 | Remove unsafe GREEN rule for `git remote` | Config — our narrowed pattern-restricted version is safe; kept |
| #36 | Add missing LLM config defaults and empty-decision reason | Binary fix |
| #38 | Pass system prompt via `--system-prompt` flag | Binary fix |
| #39 | Reclassify `printenv` and `env` from GREEN to YELLOW | **Config fix applied** — `printenv` moved to YELLOW |
| #40 | Fall back to user approval on server timeout | Binary feature |

## Codetainer-Specific Rules Preserved

- RED: credential file protection (`cat /opt/gh-config/*`)
- GREEN: `git worktree` in workflow subcommands
- GREEN: `git remote get-url/show` (pattern-restricted read-only)
- GREEN: `bunx prettier` (pattern-restricted)
- GREEN: copilot-review skill scripts
- Custom LLM `denied_paths`, scrubbing patterns, telemetry config

## Layer-Impact Assessment

1. **Container Hardening** — Not affected. Binary version change only.
2. **Network Isolation** — Not affected. No domain or iptables changes.
3. **Command Control** — Directly affected. Binary upgrade + config rebuild. Net security improvement: `printenv` GREEN→YELLOW closes secret exposure vector.

## Security Design Checklist

- **Trust anchor mutability:** `stargate.toml` template copied to `/opt/stargate/stargate.toml` at boot, locked to mode 444 on read-only rootfs. Not writable at runtime. Dynamic values (scopes, telemetry) patched from env vars before permission lock.
- **File and output visibility:** Generated config is world-readable (444) but contains no secrets — telemetry and LLM auth credentials passed via environment variables only. `denied_paths` in `[llm]` prevents file retrieval from reading credential files.
- **Allowlist vs blocklist:** GREEN rules enumerate known-safe commands (allowlist). Default decision is `yellow` (fail-closed). `denied_paths` is defense-in-depth on top of `allowed_paths` allowlist (`/workspace/**`).
- **Fail mode:** Default decision `yellow` (ask user) — fail-closed. v0.5.0 adds user-approval fallback on server timeout (also fail-closed). LLM review disabled when no API key set — falls through to yellow/ask-user.
- **Temporal safety:** Binary downloaded at build time with SHA256 verification. Config generated at boot step 8, before Stargate starts (step 9), before rootfs remount (step 10). No TOCTOU window.
- **Network exposure:** No change. Stargate listens on `127.0.0.1:9099` (localhost only).
- **Layer compensation:** This change strengthens Command Control (`printenv` GREEN→YELLOW). No layer weakened.

## Test Plan

- [x] SHA256 checksums verified against upstream `SHA256SUMS` release asset
- [x] All codetainer-specific rules confirmed present via grep
- [x] `printenv` absent from GREEN rules, present in YELLOW with `llm_review = true`
- [x] `env` YELLOW rule retains custom reason text
- [x] `generate-stargate-config.sh` sed targets (`github_owners`, `allowed_domains`, `enabled`, `service_name`) each appear exactly once at start of line
- [x] Spec compliance review passed (all 12 requirements)
- [x] Code quality review passed (no functional or security issues)
