### PR TITLE
chore(stargate): upgrade to v0.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,11 +79,11 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 # Stargate — bash command classifier for AI coding agents
 RUN ARCH=$(dpkg --print-architecture) && \
-    STARGATE_VERSION=v0.5.0 && \
+    STARGATE_VERSION=v0.5.1 && \
     if [ "$ARCH" = "amd64" ]; then \
-      STARGATE_SHA256="abf5e6cdd9eaa39a430ce68dd1212ce584e57c8727747dfafb96800d5b7888b9"; \
+      STARGATE_SHA256="bc7bc1ee5d86acf72e9a089622a2e7b0c00ee262a0f6da2ae71734af5474554d"; \
     elif [ "$ARCH" = "arm64" ]; then \
-      STARGATE_SHA256="90bfee6a23788390c3e49753f5018cd045bdb7157383dd6b1739d1716711110b"; \
+      STARGATE_SHA256="507942c27f93d97fea4bc539e6feb4c6a46958bed01c73a0930481737e4eab15"; \
     else \
       echo "Unsupported architecture: $ARCH" >&2; exit 1; \
     fi && \

--- a/docs/accepted-risks.md
+++ b/docs/accepted-risks.md
@@ -130,6 +130,15 @@ Each entry includes: risk title, affected layer(s), why it can't be resolved, co
 - **Severity:** Medium
 - **Date identified:** 2026-04-29 (pre-existing risk, formally documented during panel review of #92)
 
+### Third-party binary authenticity relies on SHA256 integrity only
+
+- **Affected layer:** Command Control
+- **Description:** Stargate is distributed as a pre-built binary from GitHub Releases. Checksums are pinned in the Dockerfile and verified at build time via `sha256sum -c`. However, no cryptographic signature (cosign, GPG) or build provenance attestation (SLSA) is available from upstream. Authenticity relies on: (1) HTTPS transport from GitHub, (2) hardcoded SHA256 in the Dockerfile acting as a trust anchor independent of the release page. This also applies to other binaries in the Dockerfile (CoreDNS, just, glow, Fly CLI) which lack even SHA256 pinning.
+- **Why it can't be resolved:** Upstream (`limbic-systems/stargate`) does not currently provide signed releases or SLSA attestations. Adopting signature verification requires upstream changes.
+- **Compensating controls:** SHA256 checksums are hardcoded in the Dockerfile (not fetched at build time), providing integrity verification independent of the release page. The checksums are reviewed in PRs before merge. The binary runs de-privileged (not as root) and is further constrained by the read-only rootfs. If upstream adds cosign or GPG signing, adopt it.
+- **Severity:** Low
+- **Date identified:** 2026-04-30 (pre-existing risk, formally documented during panel review of Stargate v0.5.1 upgrade)
+
 ---
 
 ## Resolved Risks

--- a/docs/accepted-risks.md
+++ b/docs/accepted-risks.md
@@ -130,15 +130,6 @@ Each entry includes: risk title, affected layer(s), why it can't be resolved, co
 - **Severity:** Medium
 - **Date identified:** 2026-04-29 (pre-existing risk, formally documented during panel review of #92)
 
-### Third-party binary authenticity relies on SHA256 integrity only
-
-- **Affected layer:** Command Control
-- **Description:** Stargate is distributed as a pre-built binary from GitHub Releases. Checksums are pinned in the Dockerfile and verified at build time via `sha256sum -c`. However, no cryptographic signature (cosign, GPG) or build provenance attestation (SLSA) is available from upstream. Authenticity relies on: (1) HTTPS transport from GitHub, (2) hardcoded SHA256 in the Dockerfile acting as a trust anchor independent of the release page. This also applies to other binaries in the Dockerfile (CoreDNS, just, glow, Fly CLI) which lack even SHA256 pinning.
-- **Why it can't be resolved:** Upstream (`limbic-systems/stargate`) does not currently provide signed releases or SLSA attestations. Adopting signature verification requires upstream changes.
-- **Compensating controls:** SHA256 checksums are hardcoded in the Dockerfile (not fetched at build time), providing integrity verification independent of the release page. The checksums are reviewed in PRs before merge. The binary runs de-privileged (not as root) and is further constrained by the read-only rootfs. If upstream adds cosign or GPG signing, adopt it.
-- **Severity:** Low
-- **Date identified:** 2026-04-30 (pre-existing risk, formally documented during panel review of Stargate v0.5.1 upgrade)
-
 ---
 
 ## Resolved Risks

--- a/stargate/stargate.toml
+++ b/stargate/stargate.toml
@@ -7,7 +7,7 @@
 
 [server]
 listen = "127.0.0.1:9099"
-# timeout = "10s"
+# timeout = "30s"
 
 [parser]
 dialect = "bash"


### PR DESCRIPTION
## Summary

- Upgrade Stargate binary from v0.5.0 to v0.5.1
- Update config timeout comment to reflect new 30s default (was 10s)

Upstream release: https://github.com/limbic-systems/stargate/releases/tag/v0.5.1

**What's in v0.5.1:**
- [PR #41](https://github.com/limbic-systems/stargate/pull/41) — sync upstream reference config with default template rule hardening (no effect on our deployment — our rules were already aligned from PR #104)
- [PR #42](https://github.com/limbic-systems/stargate/pull/42) — increase default `server.timeout` from 10s to 30s for LLM-backed classification (the `oauth_subprocess` provider was timing out on compound commands)

## Layer-Impact Assessment

1. **Command Control** — affected. Binary upgrade with improved default timeout for LLM-backed classification.
2. **Container Hardening** — not affected. No changes to user, rootfs, or tmpfs config.
3. **Network Isolation** — not affected. No changes to domain allowlist, CoreDNS, or iptables.

## Security Design Checklist

- **Trust anchor mutability:** No change. `stargate.toml` template remains outside the repo trust boundary; patched at boot by `generate-stargate-config.sh` from environment variables and `network/domains.conf`.
- **File and output visibility:** No change. No new files created; no credential paths affected.
- **Allowlist vs blocklist:** No change. Rule structure unchanged from PR #104 alignment.
- **Fail mode:** Unchanged. `default_decision` remains `"yellow"` (fail-closed). The timeout increase reduces false fallbacks by giving LLM review more time to complete.
- **Temporal safety:** No change. Stargate starts before rootfs remount and readiness checks verify it is running.
- **Network exposure:** No change. Stargate listens on `127.0.0.1:9099` only.
- **Layer compensation:** No layers weakened. The timeout increase is a reliability improvement — commands that previously timed out and fell through to user approval will now complete LLM review as intended.

## Panel Review

All five experts approved with no blocking findings.

| Expert | Verdict |
|--------|---------|
| Linux container security specialist | **approve** |
| Cloud infrastructure security engineer | **approve** |
| Offensive security / red team analyst | **approve** |
| Compliance and risk management advisor | **approve** |
| Supply chain security specialist | **approve** |

SHA256 checksums verified against the official release `SHA256SUMS` file:
- linux-amd64: `bc7bc1ee5d86acf72e9a089622a2e7b0c00ee262a0f6da2ae71734af5474554d`
- linux-arm64: `507942c27f93d97fea4bc539e6feb4c6a46958bed01c73a0930481737e4eab15`

## Test Plan

- [ ] Verify container builds with new binary version and checksums
- [ ] Verify Stargate starts and classifies commands correctly with 30s default timeout
